### PR TITLE
Export: save slug mapping file

### DIFF
--- a/export-database.php
+++ b/export-database.php
@@ -38,6 +38,11 @@
 	define('REPL_PATH_NEW', "/");
 	$db = new mysqli(DB_HOST, DB_USER, DB_PASSWORD, DB_NAME);
 
+	$slug_map_file = tempnam('tmp', 'integreat-export-');
+	fwrite(STDERR, "Slug Mapping File: ". $slug_map_file . "\n");
+	$slug_map_file_resource = fopen($slug_map_file, 'w');
+	fputs($slug_map_file_resource, "Region Slug;Page ID;Translation ID;Language ID;Version;WP Slug\n");
+
 	function now() {
 		$objDateTime = new DateTime('NOW');
 		return $objDateTime->format('c');
@@ -187,7 +192,7 @@
 
 		function init_fields( $blog ) {
 			$this->fields["name"] = ( $blog->get_integreat_setting( "name_without_prefix" ) ? $blog->get_integreat_setting( "name_without_prefix" ) : $blog->get_blog_option( "blogname" ) );
-			$this->fields["slug"] = ( $blog->get_blog_option( "blogname") == "Integreat" ? "integreat" : str_replace( "/", "", $blog->path ) );
+			$this->fields["slug"] = ( $blog->slug );
 			$this->fields["aliases"] = ( $blog->get_integreat_setting( "aliases" ) != null ? $blog->get_integreat_setting( "aliases" ) : array() );
 			$this->fields["status"] = ( $blog->get_integreat_setting( "disabled" ) == 1 ? "ARCHIVED" : ( $blog->get_integreat_setting( "hidden" ) == 0 ? "ACTIVE" : "HIDDEN" ) );
 			$this->fields["latitude"] = $blog->get_integreat_setting( "latitude" );
@@ -525,11 +530,14 @@
 			$this->db = $db;
 			$this->blog_id = $blog_id;
 			$this->path = $path;
+
 			if ( $blog_id == 1 ) {
 				$this->dbprefix = "wp_";
 			} else {
 				$this->dbprefix = "wp_".$blog_id."_";
 			}
+
+			$this->slug = ( $this->get_blog_option( "blogname") == "Integreat" ? "integreat" : str_replace( "/", "", $path ) );
 		}
 
 		function get_blog_option( $option_name ) {
@@ -696,7 +704,8 @@
 					$status = "PUBLIC";
 				else
 					$status = $status; // inherit
-				$page_translations[] = new PageTranslation([
+
+				$page_translation = new PageTranslation([
 					"page"=>$mptt_node["pk"],
 					"slug"=>str_replace( ["!", "#", "&", "'", "(", ")", "*", "*", "+", ",", "/", ":", ";", "=", "?", "@", "[", "]"], "", urldecode($slug) ),
 					"title"=>$row->post_title,
@@ -710,6 +719,9 @@
 					"created_date"=>$row->post_date_gmt,
 					"last_updated"=>$row->post_modified_gmt,
 				]);
+				global $slug_map_file_resource;
+				fputs($slug_map_file_resource, "$this->slug;$mptt_node[pk];$page_translation->pk;$language_pk;$version;$slug\n");
+				$page_translations[] = $page_translation;
 				$version++;
 			}
 			return $page_translations;
@@ -923,5 +935,6 @@
 	}
 
 	fwrite(STDERR, "Dumping fixtures.");
+	fclose($slug_map_file_resource);
 	echo($fixtures->dump());
-?>
+	?>


### PR DESCRIPTION
This PR creates a file in /tmp during the database export that contains a map of WP slugs and Django translations. The format is `Region Slug;Page ID;Translation ID;Language ID;Version;WP Slug`.

Example:
```
stadtdachau;2622;63555;70;1;%e1%88%9d%e1%8a%bd%e1%88%aa
stadtdachau;2622;63556;70;2;%e1%88%9d%e1%8a%bd%e1%88%aa
stadtdachau;2623;63557;3;1;hilfsangebote
stadtdachau;2623;63558;3;2;hilfsangebote
stadtdachau;2623;63559;3;3;hilfsangebote
```