### PR TITLE
Export: skip blog ID 1, fixes WP-69

### DIFF
--- a/export-database.php
+++ b/export-database.php
@@ -853,6 +853,7 @@
 	$media_pk_map = array(); // map WP blog and attachment post ID to Django PK
 
 	foreach ( $blogs as $blog ) {
+		if ( $blog->blog_id == 1 ) { continue; }
 		$region = new Region( $blog );
 		fwrite(STDERR, "Exporting blog " . $blog->blog_id . "\n");
 		$fixtures->append( $region );


### PR DESCRIPTION
The blog with ID 1 was originally the landing page and has no use for the Integreat app.